### PR TITLE
Potential fix for code scanning alert no. 10: Information exposure through an exception

### DIFF
--- a/quests_routes.py
+++ b/quests_routes.py
@@ -124,7 +124,8 @@ def add_new_quest():
         return jsonify({"message": "Quest added successfully", "quest_id": new_quest.quest_id}), 201
     except Exception as e:
         db.session.rollback()
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"An error occurred while adding a new quest: {e}")
+        return jsonify({"error": "An internal error has occurred"}), 500
 
 # Open a quest (as Admin)
 @quests_bp.route('/edit_quest/<quest_id>', methods=['GET'])
@@ -168,7 +169,8 @@ def open_edit_quest(quest_id):
         })
         
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        app.logger.error(f"An error occurred: {e}")
+        return jsonify({"error": "An internal error has occurred"}), 500
 
 # Edit a quest (as Admin) by its ID
 @quests_bp.route('/quests/<quest_id>', methods=['PUT'])

--- a/quests_routes.py
+++ b/quests_routes.py
@@ -124,7 +124,7 @@ def add_new_quest():
         return jsonify({"message": "Quest added successfully", "quest_id": new_quest.quest_id}), 201
     except Exception as e:
         db.session.rollback()
-        app.logger.error(f"An error occurred while adding a new quest: {e}")
+        app.logger.exception(f"An error occurred while adding a new quest: {e}")
         return jsonify({"error": "An internal error has occurred"}), 500
 
 # Open a quest (as Admin)

--- a/quests_routes.py
+++ b/quests_routes.py
@@ -125,7 +125,7 @@ def add_new_quest():
     except Exception as e:
         db.session.rollback()
         app.logger.exception(f"An error occurred while adding a new quest: {e}")
-        return jsonify({"error": "An internal error has occurred"}), 500
+        return jsonify({"error": GENERIC_ERROR_MESSAGE}), 500
 
 # Open a quest (as Admin)
 @quests_bp.route('/edit_quest/<quest_id>', methods=['GET'])

--- a/quests_routes.py
+++ b/quests_routes.py
@@ -169,7 +169,7 @@ def open_edit_quest(quest_id):
         })
         
     except Exception as e:
-        app.logger.error(f"An error occurred: {e}")
+        app.logger.exception(f"An error occurred while fetching quest with ID {quest_id}: {e}")
         return jsonify({"error": "An internal error has occurred"}), 500
 
 # Edit a quest (as Admin) by its ID


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/10](https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/10)

To fix the issue, the exception message should be logged internally for debugging purposes, and a generic error message should be returned to the user. This ensures that sensitive information is not exposed while still allowing developers to diagnose issues using server-side logs.

**Steps to fix:**
1. Replace the direct exposure of `str(e)` in the JSON response with a generic error message.
2. Log the exception details internally using a logging mechanism.
3. Ensure that the logging mechanism is properly configured to capture and store error details securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
