### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/quest_submisions_routes.py
+++ b/quest_submisions_routes.py
@@ -213,7 +213,9 @@ def get_user_solutions(user_id):
         
         return jsonify(solutions), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        import logging
+        logging.error("Error occurred while retrieving user solutions: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error has occurred."}), 500
 
 # Get all correct solutions by user_id
 @quests_submissions_bp.route('/correct_solutions/<user_id>', methods=['GET'])
@@ -240,4 +242,6 @@ def get_quest_solutions(user_id):
         
         return jsonify(solutions), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        import logging
+        logging.error("Error occurred while retrieving correct solutions: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error has occurred."}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/4](https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/4)

To fix the issue, the code should avoid exposing the exception message directly to the user. Instead, a generic error message should be returned to the user, while the detailed exception information (including the stack trace) should be logged on the server for debugging purposes. This ensures that sensitive information is not exposed externally while still allowing developers to diagnose issues.

**Steps to implement the fix:**
1. Replace the `str(e)` in the response with a generic error message, such as `"An internal error has occurred."`.
2. Log the exception details (including the stack trace) on the server using Python's `logging` module or another logging mechanism.
3. Ensure that the logging mechanism is properly configured to store logs securely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
