### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/comments_routes.py
+++ b/comments_routes.py
@@ -23,7 +23,9 @@ def get_comments():
         comments_list = [dict(row) for row in comments]
         return jsonify(comments_list), 200
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        import logging
+        logging.error("Error in get_comments: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error has occurred"}), 500
 
 @comments_bp.route('/comments/<quest_id>', methods=['GET'])
 @token_required
@@ -60,7 +62,9 @@ def get_comments_by_quest(quest_id):
         return jsonify(comments), 200
 
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        import logging
+        logging.error("Error in get_comments_by_quest: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error has occurred"}), 500
 
 @comments_bp.route('/comments/<quest_id>', methods=['POST'])
 @token_required
@@ -84,4 +88,6 @@ def add_comment(quest_id):
 
         return jsonify({"message": "Comment added successfully"}), 201
     except Exception as e:
-        return jsonify({"error": str(e)}), 500
+        import logging
+        logging.error("Error in add_comment: %s", e, exc_info=True)
+        return jsonify({"error": "An internal error has occurred"}), 500

--- a/comments_routes.py
+++ b/comments_routes.py
@@ -1,4 +1,5 @@
 import requests, os
+import logging
 from flask import Blueprint, request, jsonify, send_file
 from extensions import db
 from services import token_required
@@ -23,7 +24,6 @@ def get_comments():
         comments_list = [dict(row) for row in comments]
         return jsonify(comments_list), 200
     except Exception as e:
-        import logging
         logging.error("Error in get_comments: %s", e, exc_info=True)
         return jsonify({"error": "An internal error has occurred"}), 500
 
@@ -62,7 +62,6 @@ def get_comments_by_quest(quest_id):
         return jsonify(comments), 200
 
     except Exception as e:
-        import logging
         logging.error("Error in get_comments_by_quest: %s", e, exc_info=True)
         return jsonify({"error": "An internal error has occurred"}), 500
 
@@ -88,6 +87,5 @@ def add_comment(quest_id):
 
         return jsonify({"message": "Comment added successfully"}), 201
     except Exception as e:
-        import logging
         logging.error("Error in add_comment: %s", e, exc_info=True)
         return jsonify({"error": "An internal error has occurred"}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/3](https://github.com/Skill-Forge-Project/skill_forge_quests/security/code-scanning/3)

To fix the issue, the exception message should not be directly exposed to the user. Instead, a generic error message should be returned to the user, while the detailed exception information (including the stack trace) should be logged on the server for debugging purposes. This ensures that sensitive information is not leaked to external users while still allowing developers to diagnose issues.

The changes involve:
1. Replacing `{"error": str(e)}` with a generic error message like `{"error": "An internal error has occurred"}` in the response.
2. Logging the exception details (e.g., stack trace) on the server using Python's `logging` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
